### PR TITLE
Update Hugo to v0.30.2 and remove pygments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 FROM node:8.4.0-alpine
 MAINTAINER Devin Schulz <devin@devinschulz.com>
 
-ENV HUGO_VERSION 0.26
-ENV HUGO_BINARY hugo_0.26_Linux-64bit
+ENV HUGO_VERSION 0.30.2
+ENV HUGO_BINARY hugo_0.30.2_Linux-64bit
 
-# Install Hugo, AWS CLI and Python pygments for syntax highlighting
+# Install Hugo and AWS CLI
 RUN set -x && \
   apk add --update \
   wget \
   ca-certificates \
   python \
-  py-pygments \
   py-pip && \
   wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY}.tar.gz && \
   tar -xzf ${HUGO_BINARY}.tar.gz && \


### PR DESCRIPTION
As of v28, Hugo now uses a chroma for syntax highlighting